### PR TITLE
feat: migrate payment from Stripe to PagBank PIX

### DIFF
--- a/src/app/api/checkout/create-session/route.ts
+++ b/src/app/api/checkout/create-session/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@/lib/db";
-import { getStripe } from "@/lib/stripe";
+import { createPixOrder, extractPixData } from "@/lib/pagbank";
 import { logger } from "@/lib/logger";
 import { calculatePrice } from "@/lib/pricing";
 import {
@@ -14,11 +14,6 @@ import {
 // POST /api/checkout/create-session — guest checkout, no auth required
 export async function POST(req: NextRequest) {
   try {
-    const stripe = getStripe();
-    if (!stripe) {
-      return NextResponse.json({ error: "Stripe não configurado." }, { status: 500 });
-    }
-
     const payload = await req.json();
     if (!isPlainObject(payload)) {
       return NextResponse.json({ error: "Payload inválido" }, { status: 400 });
@@ -26,8 +21,8 @@ export async function POST(req: NextRequest) {
 
     const serviceType = payload.service_type;
     const config = sanitizeConfig(payload.config);
-    const customerEmail = parseOptionalString(payload.customer_email, { maxLength: 255 });
-    const customerName = parseOptionalString(payload.customer_name, { maxLength: 100 });
+    const customerEmail = parseOptionalString(payload.customer_email, { maxLength: 255 }) ?? "cliente@elodark.com";
+    const customerName = parseOptionalString(payload.customer_name, { maxLength: 100 }) ?? "Cliente EloDark";
 
     if (!serviceType) {
       return NextResponse.json({ error: "service_type é obrigatório" }, { status: 400 });
@@ -57,61 +52,65 @@ export async function POST(req: NextRequest) {
       "coach": "Coach",
     };
 
-    // Build a human-readable description from config
-    const currentRank = parseOptionalString(config.current_rank, { maxLength: 50 });
-    const desiredRank = parseOptionalString(config.desired_rank, { maxLength: 50 });
-    const game = parseOptionalString(config.game, { maxLength: 50 });
-    const productDescription = currentRank && desiredRank
-      ? `${currentRank} → ${desiredRank}`
-      : game
-        ? `Serviço para ${game}`
-        : `Serviço de ${serviceNames[serviceType]}`;
-
-    // Create order in DB (no user_id for guest)
+    // Criar pedido no banco
     const [order] = await sql`
       INSERT INTO orders (service_type, config, price, status)
       VALUES (${serviceType}, ${JSON.stringify(config)}, ${price}, 'pending')
       RETURNING id
     `;
 
-    const origin = req.headers.get("origin") || "http://localhost:3000";
+    const amountCents = Math.round(price * 100);
+    const currentRank = parseOptionalString(config.current_rank, { maxLength: 50 });
+    const desiredRank = parseOptionalString(config.desired_rank, { maxLength: 50 });
+    const description = currentRank && desiredRank
+      ? `EloDark ${serviceNames[serviceType]} ${currentRank}→${desiredRank}`
+      : `EloDark ${serviceNames[serviceType]} #${order.id}`;
 
-    const session = await stripe.checkout.sessions.create({
-      line_items: [{
-        price_data: {
-          currency: "brl",
-          product_data: {
-            name: `EloDark — ${serviceNames[serviceType]}`,
-            description: productDescription,
-          },
-          unit_amount: Math.round(price * 100),
-        },
-        quantity: 1,
-      }],
-      mode: "payment",
-      success_url: `${origin}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${origin}/checkout/cancel?game=${encodeURIComponent(String(config.game || "league-of-legends"))}`,
-      metadata: {
-        order_id: order.id.toString(),
-        service_type: serviceType,
-      },
-      locale: "pt-BR",
-      custom_text: {
-        submit: { message: "Ao finalizar, um booster será atribuído ao seu pedido em breve." },
-      },
-      ...(customerEmail ? { customer_email: customerEmail } : {}),
-      payment_intent_data: {
-        description: `EloDark — ${serviceNames[serviceType]} — Pedido #${order.id}`,
-        statement_descriptor: "ELODARK BOOST",
-      },
+    const origin = req.headers.get("origin") || "https://elodark.com";
+    const notificationUrl = `${origin}/api/checkout/webhook`;
+
+    // Criar pedido PIX no PagBank
+    const pagbankOrder = await createPixOrder({
+      orderId: order.id,
+      amountCents,
+      description,
+      customerName,
+      customerEmail,
+      notificationUrl,
+      expiresInMinutes: 30,
     });
 
-    // Store stripe session id on the order
-    await sql`UPDATE orders SET config = config || ${JSON.stringify({ stripe_session_id: session.id })} WHERE id = ${order.id}`;
+    const { qrCodeText, qrCodeImageUrl, expirationDate, chargeId } = extractPixData(pagbankOrder);
 
-    return NextResponse.json({ sessionId: session.id, url: session.url, order_id: order.id });
+    // Salvar dados do PagBank no config do pedido (objeto limpo)
+    const mergedConfig = {
+      ...config,
+      pagbank_order_id: pagbankOrder.id,
+      pagbank_charge_id: chargeId,
+      qr_code_text: qrCodeText,
+      qr_code_image: qrCodeImageUrl,
+      pix_expires_at: expirationDate,
+      customer_email: customerEmail,
+      customer_name: customerName,
+    };
+    await sql`UPDATE orders SET config = ${JSON.stringify(mergedConfig)}::jsonb WHERE id = ${order.id}`;
+
+    logger.info("Pedido PIX criado no PagBank", {
+      orderId: order.id,
+      pagbankOrderId: pagbankOrder.id,
+      amountBRL: price,
+    });
+
+    return NextResponse.json({
+      order_id: order.id,
+      pagbank_order_id: pagbankOrder.id,
+      pix_code: qrCodeText,
+      pix_image: qrCodeImageUrl,
+      expires_at: expirationDate,
+      amount: price,
+    });
   } catch (err) {
-    logger.error("Erro ao criar sessão Stripe", err);
+    logger.error("Erro ao criar sessão de pagamento PIX", err);
     return NextResponse.json({ error: "Erro ao criar sessão de pagamento" }, { status: 500 });
   }
 }

--- a/src/app/api/checkout/sync/route.ts
+++ b/src/app/api/checkout/sync/route.ts
@@ -1,39 +1,49 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireRole, isUser } from "@/lib/auth";
 import { sql } from "@/lib/db";
-import { getStripe } from "@/lib/stripe";
+import { getOrder, isPaid } from "@/lib/pagbank";
 import { logger } from "@/lib/logger";
-import { parsePositiveInt } from "@/lib/validation";
 
-// POST /api/checkout/sync — Sync all pending orders with Stripe
+// POST /api/checkout/sync — Sync all pending orders with PagBank
 export async function POST(req: NextRequest) {
   const user = requireRole(req, "admin");
   if (!isUser(user)) return user;
 
   try {
-    const stripe = getStripe();
-    if (!stripe) return NextResponse.json({ error: "Stripe não configurado" }, { status: 500 });
-
-    const sessions = await stripe.checkout.sessions.list({ limit: 50 });
+    // Buscar pedidos pendentes que têm pagbank_order_id no config
+    const pendingOrders = await sql`
+      SELECT id, price, config
+      FROM orders
+      WHERE status = 'pending'
+        AND config->>'pagbank_order_id' IS NOT NULL
+      LIMIT 50
+    `;
 
     let synced = 0;
-    for (const session of sessions.data) {
-      if (session.payment_status === "paid" && session.metadata?.order_id) {
-        const orderId = parsePositiveInt(session.metadata.order_id);
-        if (!orderId) continue;
+    for (const order of pendingOrders) {
+      try {
+        const config =
+          typeof order.config === "string" ? JSON.parse(order.config) : order.config ?? {};
+        const pagbankOrderId: string | undefined = config?.pagbank_order_id;
+        if (!pagbankOrderId) continue;
 
-        const [order] = await sql`SELECT status FROM orders WHERE id = ${orderId}`;
-        if (order && order.status === "pending") {
-          await sql`UPDATE orders SET status = 'active', updated_at = NOW() WHERE id = ${orderId}`;
+        const pagbankOrder = await getOrder(pagbankOrderId);
+        if (isPaid(pagbankOrder)) {
+          await sql`
+            UPDATE orders SET status = 'active', updated_at = NOW()
+            WHERE id = ${order.id} AND status = 'pending'
+          `;
           synced++;
-          logger.info("Pedido sincronizado a partir do Stripe", { orderId });
+          logger.info("Pedido sincronizado via PagBank", { orderId: order.id, pagbankOrderId });
         }
+      } catch (err) {
+        logger.error("Erro ao sincronizar pedido", err, { orderId: order.id });
       }
     }
 
     return NextResponse.json({ message: `${synced} pedido(s) sincronizado(s)`, synced });
   } catch (err) {
-    logger.error("Erro ao sincronizar pedidos com Stripe", err, { userId: user.id });
+    logger.error("Erro ao sincronizar pedidos com PagBank", err, { userId: user.id });
     return NextResponse.json({ error: "Erro ao sincronizar" }, { status: 500 });
   }
 }

--- a/src/app/api/checkout/verify/[sessionId]/route.ts
+++ b/src/app/api/checkout/verify/[sessionId]/route.ts
@@ -1,54 +1,82 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@/lib/db";
-import { getStripe } from "@/lib/stripe";
+import { getOrder, isPaid } from "@/lib/pagbank";
 import { logger } from "@/lib/logger";
 import { parsePositiveInt } from "@/lib/validation";
 import { sendOrderConfirmation } from "@/lib/email";
 
-// GET /api/checkout/verify/:sessionId — no auth required (guest checkout)
-export async function GET(req: NextRequest, { params }: { params: Promise<{ sessionId: string }> }) {
+// GET /api/checkout/verify/:orderId — no auth required (guest checkout)
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
   try {
-    const stripe = getStripe();
-    if (!stripe) return NextResponse.json({ error: "Stripe não configurado" }, { status: 500 });
-
-    const { sessionId } = await params;
-    if (!sessionId) {
-      return NextResponse.json({ error: "sessionId inválido" }, { status: 400 });
+    const { sessionId: orderIdStr } = await params;
+    const orderId = parsePositiveInt(orderIdStr);
+    if (orderId === null) {
+      return NextResponse.json({ error: "orderId inválido" }, { status: 400 });
     }
 
-    const session = await stripe.checkout.sessions.retrieve(sessionId);
-    const orderId = parsePositiveInt(session.metadata?.order_id);
+    const [order] = await sql`
+      SELECT id, status, price, config FROM orders WHERE id = ${orderId}
+    `;
+    if (!order) {
+      return NextResponse.json({ error: "Pedido não encontrado" }, { status: 404 });
+    }
 
-    if (session.payment_status === "paid" && orderId !== null) {
-      const [order] = await sql`SELECT status FROM orders WHERE id = ${orderId}`;
-      if (order && order.status === "pending") {
-        await sql`UPDATE orders SET status = 'active', updated_at = NOW() WHERE id = ${orderId}`;
-        logger.info("Pedido ativado após pagamento confirmado", { orderId });
+    // Se já foi ativado, retorna imediatamente
+    if (order.status !== "pending") {
+      const config =
+        typeof order.config === "string" ? JSON.parse(order.config) : order.config ?? {};
+      return NextResponse.json({
+        payment_status: "paid",
+        order_id: orderId,
+        customer_email: config.customer_email ?? null,
+      });
+    }
 
-        // Enviar email de confirmação ao cliente
-        const customerEmail = session.customer_details?.email;
-        if (customerEmail) {
-          const [orderData] = await sql`SELECT service_type, price, config FROM orders WHERE id = ${orderId}`;
-          if (orderData) {
-            sendOrderConfirmation(customerEmail, {
-              orderId,
-              serviceType: orderData.service_type,
-              price: orderData.price,
-              config: typeof orderData.config === "string" ? JSON.parse(orderData.config) : orderData.config,
-            });
-          }
-        }
+    // Extrair pagbank_order_id do config (qualquer formato)
+    const config =
+      typeof order.config === "string" ? JSON.parse(order.config) : order.config ?? {};
+    const pagbankOrderId: string | undefined =
+      config?.pagbank_order_id ?? config?.Pagbank_order_id;
+
+    if (!pagbankOrderId) {
+      return NextResponse.json({ payment_status: "pending", order_id: orderId });
+    }
+
+    // Consultar PagBank
+    const pagbankOrder = await getOrder(pagbankOrderId);
+
+    if (isPaid(pagbankOrder)) {
+      // Ativar pedido
+      await sql`
+        UPDATE orders SET status = 'active', updated_at = NOW()
+        WHERE id = ${orderId} AND status = 'pending'
+      `;
+      logger.info("Pedido ativado via polling PagBank", { orderId, pagbankOrderId });
+
+      // Email de confirmação
+      const customerEmail = config.customer_email;
+      if (customerEmail) {
+        sendOrderConfirmation(customerEmail, {
+          orderId,
+          serviceType: order.service_type ?? "",
+          price: order.price,
+          config,
+        }).catch(() => {});
       }
+
+      return NextResponse.json({
+        payment_status: "paid",
+        order_id: orderId,
+        customer_email: customerEmail ?? null,
+      });
     }
 
-    return NextResponse.json({
-      payment_status: session.payment_status,
-      status: session.status,
-      order_id: orderId,
-      customer_email: session.customer_details?.email ?? null,
-    });
+    return NextResponse.json({ payment_status: "pending", order_id: orderId });
   } catch (err) {
-    logger.error("Erro ao verificar sessão de checkout", err);
+    logger.error("Erro ao verificar pagamento PagBank", err);
     return NextResponse.json({ error: "Erro ao verificar pagamento" }, { status: 500 });
   }
 }

--- a/src/app/api/checkout/webhook/route.ts
+++ b/src/app/api/checkout/webhook/route.ts
@@ -1,81 +1,82 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@/lib/db";
-import { getStripe } from "@/lib/stripe";
-import Stripe from "stripe";
+import { getOrder, isPaid } from "@/lib/pagbank";
 import { logger } from "@/lib/logger";
-import { parsePositiveInt } from "@/lib/validation";
 
-// POST /api/checkout/webhook — Stripe webhook (payment confirmation)
+// POST /api/checkout/webhook — PagBank notification (payment confirmation)
 export async function POST(req: NextRequest) {
-  const stripe = getStripe();
-  if (!stripe) return NextResponse.json({ error: "Stripe not configured" }, { status: 500 });
-
-  const sig = req.headers.get("stripe-signature");
-  const body = await req.text();
-  let event: Stripe.Event;
-
   try {
-    if (!process.env.STRIPE_WEBHOOK_SECRET) {
-      logger.error("STRIPE_WEBHOOK_SECRET não configurado. Webhook rejeitado.");
-      return NextResponse.json({ error: "Webhook secret not configured" }, { status: 500 });
+    const body = await req.json();
+
+    // PagBank envia { id: "ORDE_..." } ou { reference_id: "...", charges: [...] }
+    const pagbankOrderId: string | undefined = body?.id ?? body?.reference_id;
+
+    if (!pagbankOrderId) {
+      logger.error("Webhook PagBank: payload sem id", { body });
+      return NextResponse.json({ error: "Payload inválido" }, { status: 400 });
     }
-    if (!sig) {
-      return NextResponse.json({ error: "Missing stripe-signature header" }, { status: 400 });
+
+    // Buscar pedido no banco pelo pagbank_order_id
+    const [order] = await sql`
+      SELECT id, status, price
+      FROM orders
+      WHERE config->>'pagbank_order_id' = ${pagbankOrderId}
+      LIMIT 1
+    `;
+
+    if (!order) {
+      // Pode ser notificação de outro recurso — retorna 200 para o PagBank não reenviar
+      logger.info("Webhook PagBank: pedido não encontrado para", { pagbankOrderId });
+      return NextResponse.json({ received: true });
     }
-    event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET);
+
+    if (order.status !== "pending") {
+      // Já processado
+      return NextResponse.json({ received: true });
+    }
+
+    // Consultar status atualizado na API PagBank
+    const pagbankOrder = await getOrder(pagbankOrderId);
+
+    if (!isPaid(pagbankOrder)) {
+      return NextResponse.json({ received: true });
+    }
+
+    // Validar valor pago
+    const charge = pagbankOrder.charges?.[0] as unknown as { amount?: { value?: number } } | undefined;
+    const paidCents = charge?.amount?.value ?? 0;
+    const expectedCents = Math.round(parseFloat(String(order.price)) * 100);
+    const diff = Math.abs(paidCents - expectedCents);
+
+    if (paidCents > 0 && diff > 1) {
+      logger.error("Webhook PagBank: valor pago diverge", {
+        orderId: order.id,
+        paidCents,
+        expectedCents,
+      });
+      await sql`
+        UPDATE orders
+        SET status = 'cancelled',
+            updated_at = NOW()
+        WHERE id = ${order.id} AND status = 'pending'
+      `;
+      return NextResponse.json({ received: true });
+    }
+
+    // Ativar pedido
+    await sql`
+      UPDATE orders SET status = 'active', updated_at = NOW()
+      WHERE id = ${order.id} AND status = 'pending'
+    `;
+    logger.info("Pedido ativado via webhook PagBank", {
+      orderId: order.id,
+      pagbankOrderId,
+      amountBRL: paidCents / 100,
+    });
+
+    return NextResponse.json({ received: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    logger.error("Erro de assinatura no webhook Stripe", err);
-    return NextResponse.json({ error: `Webhook Error: ${message}` }, { status: 400 });
+    logger.error("Erro ao processar webhook PagBank", err);
+    return NextResponse.json({ error: "Erro interno" }, { status: 500 });
   }
-
-  if (event.type === "checkout.session.completed") {
-    const session = event.data.object as Stripe.Checkout.Session;
-    const orderId = parsePositiveInt(session.metadata?.order_id);
-
-    if (orderId !== null && session.payment_status === "paid") {
-      try {
-        // Buscar pedido no banco para validar o valor
-        const [order] = await sql`
-          SELECT id, price, status FROM orders WHERE id = ${orderId}
-        `;
-
-        if (!order) {
-          logger.error("Webhook: pedido não encontrado", { orderId });
-          return NextResponse.json({ received: true }); // retorna 200 para Stripe não reenviar
-        }
-
-        // Validar valor pago (Stripe envia em centavos)
-        const paidAmountCents = session.amount_total ?? 0;
-        const expectedAmountCents = Math.round(parseFloat(order.price) * 100);
-        const diff = Math.abs(paidAmountCents - expectedAmountCents);
-
-        if (diff > 1) { // tolerancia de 1 centavo para arredondamento
-          logger.error("Webhook: valor pago diverge do pedido", {
-            orderId,
-            paidAmountCents,
-            expectedAmountCents,
-          });
-          // Marcar como suspeito em vez de ativar
-          await sql`
-            UPDATE orders SET status = 'cancelled', notes = ${'FRAUDE: valor pago (' + (paidAmountCents / 100).toFixed(2) + ') difere do pedido (' + (expectedAmountCents / 100).toFixed(2) + ')'}, updated_at = NOW()
-            WHERE id = ${orderId} AND status = 'pending'
-          `;
-          return NextResponse.json({ received: true });
-        }
-
-        // Valor confere — ativar pedido
-        await sql`
-          UPDATE orders SET status = 'active', updated_at = NOW()
-          WHERE id = ${orderId} AND status = 'pending'
-        `;
-        logger.info("Pedido pago confirmado via Stripe", { orderId, amountBRL: paidAmountCents / 100 });
-      } catch (err) {
-        logger.error("Falha ao atualizar pedido após webhook Stripe", err, { orderId });
-        return NextResponse.json({ error: "Falha ao processar webhook" }, { status: 500 });
-      }
-    }
-  }
-
-  return NextResponse.json({ received: true });
 }

--- a/src/app/boost/[game]/page.tsx
+++ b/src/app/boost/[game]/page.tsx
@@ -449,10 +449,16 @@ export default function OrderConfiguratorPage() {
         setCheckoutError(data.error || "Erro ao criar sessão de pagamento");
         return;
       }
-      if (data.url) {
-        window.location.href = data.url;
+      if (data.pix_code && data.order_id) {
+        const params = new URLSearchParams({
+          order_id: String(data.order_id),
+          pix_code: data.pix_code,
+          ...(data.pix_image ? { pix_image: data.pix_image } : {}),
+          ...(data.expires_at ? { expires_at: data.expires_at } : {}),
+        });
+        window.location.href = `/checkout/pix?${params.toString()}`;
       } else {
-        setCheckoutError("Erro ao criar sessão de pagamento");
+        setCheckoutError("Erro ao gerar PIX. Tente novamente.");
       }
     } catch (error: any) {
       setCheckoutError(error.message || "Erro ao conectar ao servidor");

--- a/src/app/checkout/cancel/page.tsx
+++ b/src/app/checkout/cancel/page.tsx
@@ -37,7 +37,7 @@ function CancelContent() {
       <div className="w-full glass-card rounded-2xl border border-white/5 p-6 space-y-4">
         <h3 className="text-sm font-bold text-white/40 uppercase tracking-widest text-left">Por que continuar?</h3>
         {[
-          { icon: "verified_user", label: "100% Seguro", desc: "Pagamento processado pela Stripe com criptografia total." },
+          { icon: "verified_user", label: "100% Seguro", desc: "Pagamento PIX processado pelo PagBank com criptografia total." },
           { icon: "schedule", label: "Entrega Rápida", desc: "Boosters disponíveis 24h. Início em até 1 hora após o pagamento." },
           { icon: "emoji_events", label: "Garantia de Entrega", desc: "Se não entregarmos, devolvemos seu dinheiro." },
         ].map((item, i) => (

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -13,15 +13,15 @@ export default function CheckoutPage() {
       <main className="flex-1 flex items-center justify-center px-6 py-20">
         <div className="text-center max-w-md space-y-6">
           <div className="w-20 h-20 mx-auto rounded-full bg-primary/20 flex items-center justify-center">
-            <Icon name="shopping_cart_checkout" className="text-primary" size={48} />
+            <Icon name="pix" className="text-primary" size={48} />
           </div>
 
-          <h2 className="text-3xl font-bold">Pagamento via Stripe</h2>
+          <h2 className="text-3xl font-bold">Pagamento via PIX</h2>
 
           <p className="text-gray-400">
-            O pagamento é processado de forma segura pelo Stripe. Configure seu
+            O pagamento é processado de forma segura pelo PagBank via PIX. Configure seu
             pedido na página de boost e clique em <strong>Finalizar Compra</strong>{" "}
-            para ser redirecionado.
+            para gerar o QR Code.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-3 justify-center pt-4">
@@ -41,7 +41,7 @@ export default function CheckoutPage() {
             <div className="flex items-center gap-1">
               <Icon name="verified_user" size={14} />
               <span className="text-[10px] font-bold uppercase">
-                Segurança Norton
+                PagBank Seguro
               </span>
             </div>
             <div className="flex items-center gap-1">

--- a/src/app/checkout/pix/page.tsx
+++ b/src/app/checkout/pix/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Image from "next/image";
+import { Navbar } from "@/components/layout/navbar";
+import { Icon } from "@/components/ui/icon";
+
+const POLL_INTERVAL_MS = 5000;
+
+function PixContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const orderId = searchParams.get("order_id");
+  const pixCode = searchParams.get("pix_code");
+  const pixImage = searchParams.get("pix_image");
+  const expiresAt = searchParams.get("expires_at");
+
+  const [copied, setCopied] = useState(false);
+  const [status, setStatus] = useState<"waiting" | "paid" | "expired" | "error">("waiting");
+  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Contagem regressiva
+  useEffect(() => {
+    if (!expiresAt) return;
+    const expiry = new Date(expiresAt).getTime();
+
+    const tick = () => {
+      const remaining = Math.max(0, Math.floor((expiry - Date.now()) / 1000));
+      setTimeLeft(remaining);
+      if (remaining === 0) setStatus("expired");
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  // Polling
+  useEffect(() => {
+    if (!orderId) return;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/checkout/verify/${orderId}`);
+        const data = await res.json();
+        if (data.payment_status === "paid") {
+          setStatus("paid");
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.push(`/checkout/success?order_id=${orderId}`), 1500);
+        }
+      } catch {
+        // silencia erros de rede, continua polling
+      }
+    };
+
+    poll(); // verificação imediata
+    pollRef.current = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [orderId, router]);
+
+  function handleCopy() {
+    if (!pixCode) return;
+    navigator.clipboard.writeText(pixCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    });
+  }
+
+  function formatTime(seconds: number) {
+    const m = Math.floor(seconds / 60).toString().padStart(2, "0");
+    const s = (seconds % 60).toString().padStart(2, "0");
+    return `${m}:${s}`;
+  }
+
+  if (!orderId || !pixCode) {
+    return (
+      <div className="flex flex-col items-center gap-6 text-center max-w-md">
+        <div className="w-24 h-24 rounded-full bg-red-500/10 border border-red-500/30 flex items-center justify-center">
+          <Icon name="error" className="text-red-400" size={40} filled />
+        </div>
+        <div>
+          <h1 className="text-2xl font-black mb-2 text-red-400">Link inválido</h1>
+          <p className="text-white/50 text-sm">Dados do PIX não encontrados. Tente novamente.</p>
+        </div>
+        <a
+          href="/boost/league-of-legends"
+          className="px-6 py-3 rounded-xl bg-primary text-white text-sm font-bold hover:bg-primary/90 transition-all"
+        >
+          Tentar Novamente
+        </a>
+      </div>
+    );
+  }
+
+  if (status === "paid") {
+    return (
+      <div className="flex flex-col items-center gap-6 text-center max-w-md">
+        <div className="relative">
+          <div className="absolute inset-0 rounded-full bg-green-500/20 blur-2xl scale-150" />
+          <div className="relative w-28 h-28 rounded-full bg-green-500/10 border-2 border-green-500/40 flex items-center justify-center shadow-[0_0_40px_rgba(34,197,94,0.3)]">
+            <Icon name="check_circle" className="text-green-400" size={52} filled />
+          </div>
+        </div>
+        <div>
+          <h1 className="text-3xl font-black mb-2 text-green-400">Pagamento Confirmado!</h1>
+          <p className="text-white/60 text-sm">Redirecionando...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "expired") {
+    return (
+      <div className="flex flex-col items-center gap-6 text-center max-w-md">
+        <div className="w-24 h-24 rounded-full bg-orange-500/10 border border-orange-500/30 flex items-center justify-center">
+          <Icon name="timer_off" className="text-orange-400" size={40} />
+        </div>
+        <div>
+          <h1 className="text-2xl font-black mb-2 text-orange-400">PIX Expirado</h1>
+          <p className="text-white/50 text-sm">O QR Code expirou. Crie um novo pedido para continuar.</p>
+        </div>
+        <a
+          href="/boost/league-of-legends"
+          className="px-6 py-3 rounded-xl bg-primary text-white text-sm font-bold hover:bg-primary/90 transition-all"
+        >
+          Novo Pedido
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-8 text-center max-w-lg w-full">
+      {/* Header */}
+      <div>
+        <div className="inline-flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-full px-4 py-1 text-primary text-xs font-bold uppercase tracking-widest mb-4">
+          <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+          Aguardando Pagamento
+        </div>
+        <h1 className="text-3xl font-black mb-2">Pague via PIX</h1>
+        <p className="text-white/50 text-sm">
+          Escaneie o QR Code ou copie o código abaixo. O pagamento é confirmado automaticamente.
+        </p>
+      </div>
+
+      {/* Timer */}
+      {timeLeft !== null && (
+        <div className="flex items-center gap-2 text-white/50 text-sm">
+          <Icon name="timer" size={16} />
+          <span>Expira em <strong className={timeLeft < 120 ? "text-orange-400" : "text-white"}>{formatTime(timeLeft)}</strong></span>
+        </div>
+      )}
+
+      {/* QR Code */}
+      <div className="glass-card rounded-2xl border border-white/10 p-6 w-full flex flex-col items-center gap-4">
+        {pixImage ? (
+          <Image
+            src={pixImage}
+            alt="QR Code PIX"
+            width={220}
+            height={220}
+            className="rounded-xl bg-white p-2"
+            unoptimized
+          />
+        ) : (
+          <div className="w-[220px] h-[220px] rounded-xl bg-white/5 border border-white/10 flex items-center justify-center">
+            <Icon name="qr_code_2" className="text-white/30" size={80} />
+          </div>
+        )}
+
+        <p className="text-xs text-white/40">Pedido <strong className="text-white/70">#{orderId}</strong></p>
+      </div>
+
+      {/* Copia e cola */}
+      <div className="w-full glass-card rounded-2xl border border-white/10 p-4 space-y-3">
+        <p className="text-xs font-bold text-white/40 uppercase tracking-widest text-left">Pix Copia e Cola</p>
+        <div className="flex items-center gap-3">
+          <code className="flex-1 text-xs text-white/70 bg-white/5 rounded-lg px-3 py-2.5 truncate font-mono">
+            {pixCode}
+          </code>
+          <button
+            onClick={handleCopy}
+            className={`shrink-0 px-4 py-2.5 rounded-lg text-xs font-bold transition-all ${
+              copied
+                ? "bg-green-500/20 border border-green-500/30 text-green-400"
+                : "bg-primary/10 border border-primary/20 text-primary hover:bg-primary/20"
+            }`}
+          >
+            {copied ? (
+              <span className="flex items-center gap-1.5"><Icon name="check" size={14} />Copiado!</span>
+            ) : (
+              <span className="flex items-center gap-1.5"><Icon name="content_copy" size={14} />Copiar</span>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Instrução */}
+      <div className="w-full glass-card rounded-2xl border border-white/5 p-5 space-y-3">
+        <h3 className="text-xs font-bold text-white/40 uppercase tracking-widest text-left">Como pagar</h3>
+        {[
+          { icon: "smartphone", label: "Abra seu banco", desc: "Acesse o app do seu banco ou carteira digital." },
+          { icon: "qr_code_scanner", label: "Escaneie o QR Code", desc: "Ou cole o código PIX no campo indicado." },
+          { icon: "check_circle", label: "Confirme o pagamento", desc: "Seu pedido é ativado automaticamente após a confirmação." },
+        ].map((step, i) => (
+          <div key={i} className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name={step.icon} className="text-primary" size={16} />
+            </div>
+            <div className="text-left">
+              <p className="text-xs font-bold">{step.label}</p>
+              <p className="text-xs text-white/40">{step.desc}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Suporte */}
+      <a
+        href="https://wa.me/5515998594085"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-white/30 hover:text-green-400 transition-colors flex items-center gap-1.5"
+      >
+        <Icon name="support_agent" size={14} />
+        Precisa de ajuda? Fale com nosso suporte no WhatsApp
+      </a>
+    </div>
+  );
+}
+
+export default function PixPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1 flex items-center justify-center px-6 py-16">
+        <Suspense
+          fallback={
+            <div className="w-24 h-24 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center animate-pulse">
+              <Icon name="qr_code_2" className="text-primary" size={40} />
+            </div>
+          }
+        >
+          <PixContent />
+        </Suspense>
+      </main>
+    </div>
+  );
+}

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -13,15 +13,16 @@ type VerifyResult =
 
 function SuccessContent() {
   const searchParams = useSearchParams();
-  const sessionId = searchParams.get("session_id");
+  // Suporte a ambos: order_id (PagBank) e session_id (legado)
+  const orderId = searchParams.get("order_id");
   const [result, setResult] = useState<VerifyResult>({ state: "loading" });
 
   useEffect(() => {
-    if (!sessionId) {
-      setResult({ state: "error", message: "Sessão de pagamento não encontrada." });
+    if (!orderId) {
+      setResult({ state: "error", message: "Pedido não encontrado." });
       return;
     }
-    fetch(`/api/checkout/verify/${sessionId}`)
+    fetch(`/api/checkout/verify/${orderId}`)
       .then((r) => r.json())
       .then((data) => {
         if (data.error) {
@@ -29,15 +30,22 @@ function SuccessContent() {
           return;
         }
         if (data.payment_status !== "paid") {
-          setResult({ state: "error", message: "Pagamento ainda não confirmado. Aguarde alguns instantes e recarregue a página." });
+          setResult({
+            state: "error",
+            message: "Pagamento ainda não confirmado. Aguarde alguns instantes e recarregue a página.",
+          });
           return;
         }
-        setResult({ state: "success", orderId: data.order_id ?? null, customerEmail: data.customer_email ?? null });
+        setResult({
+          state: "success",
+          orderId: data.order_id ?? null,
+          customerEmail: data.customer_email ?? null,
+        });
       })
       .catch(() => {
         setResult({ state: "error", message: "Erro ao conectar ao servidor." });
       });
-  }, [sessionId]);
+  }, [orderId]);
 
   if (result.state === "loading") {
     return (
@@ -67,7 +75,10 @@ function SuccessContent() {
           <p className="text-white/50 text-sm">{result.message}</p>
         </div>
         <div className="flex flex-col sm:flex-row gap-3 w-full">
-          <Link href="/" className="flex-1 px-6 py-3 rounded-xl bg-white/5 border border-white/10 text-sm font-bold text-center hover:bg-white/10 transition-all">
+          <Link
+            href="/"
+            className="flex-1 px-6 py-3 rounded-xl bg-white/5 border border-white/10 text-sm font-bold text-center hover:bg-white/10 transition-all"
+          >
             Voltar ao Início
           </Link>
           <a
@@ -86,7 +97,6 @@ function SuccessContent() {
 
   return (
     <div className="flex flex-col items-center gap-8 text-center max-w-lg w-full">
-      {/* Animated success icon */}
       <div className="relative">
         <div className="absolute inset-0 rounded-full bg-green-500/20 blur-2xl scale-150" />
         <div className="relative w-28 h-28 rounded-full bg-green-500/10 border-2 border-green-500/40 flex items-center justify-center shadow-[0_0_40px_rgba(34,197,94,0.3)]">
@@ -94,7 +104,6 @@ function SuccessContent() {
         </div>
       </div>
 
-      {/* Title */}
       <div>
         <div className="inline-flex items-center gap-2 bg-green-500/10 border border-green-500/20 rounded-full px-4 py-1 text-green-400 text-xs font-bold uppercase tracking-widest mb-4">
           <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
@@ -104,21 +113,23 @@ function SuccessContent() {
           Pedido Recebido!{result.orderId ? ` #${result.orderId}` : ""}
         </h1>
         <p className="text-white/60 text-base leading-relaxed">
-          Seu pagamento foi processado com sucesso.{" "}
+          Seu pagamento PIX foi processado com sucesso.{" "}
           {result.customerEmail && (
-            <>Enviamos uma confirmação para <span className="text-white font-semibold">{result.customerEmail}</span>.</>
+            <>
+              Enviamos uma confirmação para{" "}
+              <span className="text-white font-semibold">{result.customerEmail}</span>.
+            </>
           )}{" "}
           Um booster será atribuído ao seu pedido em breve.
         </p>
       </div>
 
-      {/* Steps */}
       <div className="w-full glass-card rounded-2xl border border-white/5 p-6 space-y-4">
         <h3 className="text-sm font-bold text-white/40 uppercase tracking-widest text-left">Próximos Passos</h3>
         {[
-          { icon: "person_search", label: "Atribuição de Booster", desc: "Um booster qualificado será atribuído ao seu pedido.", done: false },
-          { icon: "sports_esports", label: "Início do Serviço", desc: "O booster entrará em contato e iniciará o boost.", done: false },
-          { icon: "emoji_events", label: "Entrega Garantida", desc: "Você alcançará o rank desejado dentro do prazo.", done: false },
+          { icon: "person_search", label: "Atribuição de Booster", desc: "Um booster qualificado será atribuído ao seu pedido." },
+          { icon: "sports_esports", label: "Início do Serviço", desc: "O booster entrará em contato e iniciará o boost." },
+          { icon: "emoji_events", label: "Entrega Garantida", desc: "Você alcançará o rank desejado dentro do prazo." },
         ].map((step, i) => (
           <div key={i} className="flex items-start gap-4">
             <div className="w-10 h-10 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center shrink-0 mt-0.5">
@@ -132,7 +143,6 @@ function SuccessContent() {
         ))}
       </div>
 
-      {/* Actions */}
       <div className="flex flex-col sm:flex-row gap-3 w-full">
         <Link
           href="/"

--- a/src/lib/pagbank.ts
+++ b/src/lib/pagbank.ts
@@ -1,0 +1,159 @@
+// PagBank API client (PIX payments)
+
+const PAGBANK_BASE_URL =
+  process.env.PAGBANK_ENV === "sandbox"
+    ? "https://sandbox.api.pagseguro.com"
+    : "https://api.pagseguro.com";
+
+function getToken(): string {
+  const token = process.env.PAGBANK_TOKEN;
+  if (!token) throw new Error("PAGBANK_TOKEN não configurado");
+  return token;
+}
+
+async function pagbankFetch(path: string, options?: RequestInit): Promise<Response> {
+  const res = await fetch(`${PAGBANK_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${getToken()}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...(options?.headers ?? {}),
+    },
+  });
+  return res;
+}
+
+export interface PagBankQrCode {
+  id: string;
+  text: string;
+  expiration_date: string;
+  links: { rel: string; href: string; media: string }[];
+}
+
+export interface PagBankCharge {
+  id: string;
+  status: string; // WAITING | PAID | DECLINED | CANCELED
+  payment_method: {
+    type: string;
+    pix?: { qr_codes?: PagBankQrCode[] };
+  };
+}
+
+export interface PagBankOrder {
+  id: string;
+  reference_id: string;
+  status: string; // WAITING | PAID | DECLINED | CANCELED
+  charges: PagBankCharge[];
+}
+
+export interface CreatePixOrderParams {
+  orderId: number;
+  amountCents: number; // valor em centavos
+  description: string;
+  customerName: string;
+  customerEmail: string;
+  notificationUrl: string;
+  expiresInMinutes?: number; // padrão: 30
+}
+
+export async function createPixOrder(params: CreatePixOrderParams): Promise<PagBankOrder> {
+  const {
+    orderId,
+    amountCents,
+    description,
+    customerName,
+    customerEmail,
+    notificationUrl,
+    expiresInMinutes = 30,
+  } = params;
+
+  const expirationDate = new Date(Date.now() + expiresInMinutes * 60 * 1000).toISOString();
+
+  const body = {
+    reference_id: `elodark-${orderId}`,
+    customer: {
+      name: customerName || "Cliente EloDark",
+      email: customerEmail || "cliente@elodark.com",
+    },
+    items: [
+      {
+        reference_id: `order-${orderId}`,
+        name: description.slice(0, 64),
+        quantity: 1,
+        unit_amount: amountCents,
+      },
+    ],
+    notification_urls: [notificationUrl],
+    charges: [
+      {
+        reference_id: `charge-${orderId}`,
+        description: description.slice(0, 64),
+        amount: {
+          value: amountCents,
+          currency: "BRL",
+        },
+        payment_method: {
+          type: "PIX",
+          installments: 1,
+          capture: true,
+          pix: {
+            expiration_date: expirationDate,
+          },
+        },
+      },
+    ],
+  };
+
+  const res = await pagbankFetch("/orders", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`PagBank create order error ${res.status}: ${text}`);
+  }
+
+  return res.json() as Promise<PagBankOrder>;
+}
+
+export async function getOrder(pagbankOrderId: string): Promise<PagBankOrder> {
+  const res = await pagbankFetch(`/orders/${pagbankOrderId}`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`PagBank get order error ${res.status}: ${text}`);
+  }
+  return res.json() as Promise<PagBankOrder>;
+}
+
+/** Retorna o QR code text (copia-e-cola) e a URL da imagem PNG */
+export function extractPixData(order: PagBankOrder): {
+  qrCodeText: string | null;
+  qrCodeImageUrl: string | null;
+  expirationDate: string | null;
+  chargeId: string | null;
+} {
+  const charge = order.charges?.[0];
+  if (!charge) return { qrCodeText: null, qrCodeImageUrl: null, expirationDate: null, chargeId: null };
+
+  const qrCode = charge.payment_method?.pix?.qr_codes?.[0];
+  if (!qrCode) return { qrCodeText: null, qrCodeImageUrl: null, expirationDate: null, chargeId: charge.id };
+
+  const pngLink = qrCode.links?.find((l) => l.rel === "QRCODE.PNG" || l.media === "image/png");
+
+  return {
+    qrCodeText: qrCode.text ?? null,
+    qrCodeImageUrl: pngLink?.href ?? null,
+    expirationDate: qrCode.expiration_date ?? null,
+    chargeId: charge.id,
+  };
+}
+
+/** Verifica se o pedido PagBank está pago */
+export function isPaid(order: PagBankOrder): boolean {
+  return (
+    order.charges?.some((c) => c.status === "PAID") === true ||
+    order.status === "PAID"
+  );
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,6 +1,0 @@
-import Stripe from "stripe";
-
-export function getStripe(): Stripe | null {
-  if (!process.env.STRIPE_SECRET_KEY) return null;
-  return new Stripe(process.env.STRIPE_SECRET_KEY);
-}


### PR DESCRIPTION
- Add src/lib/pagbank.ts: PagBank API client (createPixOrder, getOrder, isPaid)
- Rewrite create-session: creates PagBank PIX order, returns QR code data
- Add /checkout/pix page: shows QR code + pix code with auto-polling every 5s
- Rewrite verify/[orderId]: polls PagBank API and activates order when paid
- Rewrite webhook: handles PagBank notifications with amount validation
- Rewrite sync: reconciles pending orders via PagBank API (admin tool)
- Update boost page: redirects to /checkout/pix after order creation
- Update success page: accepts order_id param (PagBank flow)
- Remove stripe.ts and all Stripe references